### PR TITLE
Added compatibility with Dojo i18n

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,8 @@ module.exports = function (content) {
 
 	// root lang
 	ret.__root = json.root;
+	// provide a fallback for dynamically required loading with things like dojo/i18n
+	ret.root = json.root;
 
 	// merge
 	// 1. langs in `root`
@@ -125,6 +127,8 @@ module.exports = function (content) {
 
 		// give this lang definition to ret
 		ret['__' + language] = getJsonFromFile(__content);
+		// provide a fallback for dynamically required loading with things like dojo/i18n
+		ret[language] = getJsonFromFile(__content);
 	}
 
 	// amdi18n is the final lang definition.


### PR DESCRIPTION
There are some unique circumstances where a file bundled by webpack may be required by something external to it, like requirejs or dojo. For Dojo, in particular, it looks for this structure on the module is returned. If this doesn't exist, it will fail to translate. This should not impact this loader in anyway shape or form. It is a quiet addition to provide backwards compatibility with annoying systems

See loading requirement here: https://github.com/dojo/dojo/blob/master/i18n.js#L90