### PR TITLE
Issue 26

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,9 +165,9 @@ module.exports = function (content) {
 	var init = function(language){
 		// get the default language
 		if(!language){
-			if(window._i18n && window._i18n.locale){
+			if(typeof window !== 'undefined' && window._i18n && window._i18n.locale){
 				language = window._i18n.locale;
-			}else if(document.documentElement.lang){
+			}else if(typeof document !== 'undefined' && document.documentElement.lang){
 				language = document.documentElement.lang;
 			}else{
 				language = 'root';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "webpack i18n loader similar to require.js i18n plugin",
   "main": "index.js",
   "scripts": {
-    "test": "cd tests &&../node_modules/.bin/webpack && ../node_modules/.bin/mocha ../tests/main.js"
+    "test": "cd tests && webpack && mocha ../tests/main.js"
   },
   "repository": {
     "type": "git",

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,7 +1,21 @@
 var should = require('should');
-// mock
-global.document = {documentElement:{}};
-global.window = {document:document};
+
+function mockWindowAndDocument() {
+	// Currently, the tests only run on Node, so window will never exist.
+	// But if the tests could run in the browser, we don't want to overwrite
+	// window or document.
+	var windowExists = typeof window !== 'undefined';
+	if (!windowExists) {
+		document = {documentElement:{}};
+		window = {document:document};
+	}
+	return function() {
+		if (!windowExists) {
+			delete window;
+			delete document;
+		}
+	};
+}
 
 describe('basic function', function() {
 	var lang = require('./basic/bundle');
@@ -23,9 +37,10 @@ describe('basic function', function() {
 });
 
 describe('fallback', function() {
-	global.window._i18n = {locale:'zh-hk'};
+	var restoreWindow = mockWindowAndDocument();
+	window._i18n = {locale:'zh-hk'};
 	var lang = require('./fallback/bundle');
-	delete global.window._i18n;
+	restoreWindow();
 	it('fallback to root', function() {
 		lang.FALLBACK.should.equal('FALLBACK');
 	});


### PR DESCRIPTION
Run in Node without errors

The tests used to always mock window and document because the tests were
always run in a Node environment, and therefore these objects did not
exist.

This change lets webpack-amdi18n-loader run in a Node environment by
testing for the existence of window/document before attempting to use
them.