### PR TITLE
fix: don't use navigator.languages if it doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,11 @@ module.exports = function (content) {
 			}else if(typeof document !== 'undefined' && document.documentElement.lang){
 				language = document.documentElement.lang;
 			}else if(typeof navigator !== 'undefined' && (navigator.languages || navigator.language || navigator.userLanguage)){
-				language = (navigator.languages[0] || navigator.language || navigator.userLanguage || 'root').toLowerCase();
+				// navigator.languages does not exist in IE 11
+				language = (navigator.languages && navigator.languages[0]) ||
+					navigator.language ||
+					navigator.userLanguage;
+				language = (language || 'root').toLowerCase();
 			}else{
 				language = 'root';
 			}


### PR DESCRIPTION
Fixes #28 