### PR TITLE
esm now allows export default{ without whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function (content) {
 			script = 'json = ' + content;
 		}else{
 			// turn esm to commonjs2
-			content = content.replace(/export[\s\r\n]+default[\s\r\n]+/, 'module.exports=');
+			content = content.replace(/export[\s\r\n]+default[\s\r\n]*/, 'module.exports=');
 			// define the 'define()' function
 			script = 'var define=' + mockDefine.toString() + ';' +
 				// execute 'define()' function


### PR DESCRIPTION
In some cases, the code that is consumed by the loader is already minified and therefore whitespace is trimmed.