### PR TITLE
boolean flag no longer ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ module.exports = function (content) {
 		if(language === 'root' && typeof json.root !== 'boolean') continue;
 		if(enableList.length && enableList.indexOf(language) === -1) continue;
 		if(disableList.indexOf(language) > -1) continue;
+		if (json[language] === false) continue; // ignore disabled languages
 		allLangs.push(language);
 	}
 	enableList.forEach(function(language){

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function (content) {
 		if(language === 'root' && typeof json.root !== 'boolean') continue;
 		if(enableList.length && enableList.indexOf(language) === -1) continue;
 		if(disableList.indexOf(language) > -1) continue;
-		if (json[language] === false) continue; // ignore disabled languages
+		if(json[language] === false) continue; // ignore disabled languages
 		allLangs.push(language);
 	}
 	enableList.forEach(function(language){


### PR DESCRIPTION
Both languages are loaded here:
```
{
 'de-DE': true,
 'en-US': false
}
```
I think en-US should not be loaded if specifically set to false.